### PR TITLE
Add DetainmentExperience model and news ticker

### DIFF
--- a/backend/api/app/main.py
+++ b/backend/api/app/main.py
@@ -15,6 +15,7 @@ from app.routers import (
     booking,
     chat,
     facilities,
+    experiences,
 )
 from app.limits import limiter
 from app.utils.lifespan import lifespan
@@ -54,6 +55,7 @@ app.include_router(disposition.router)
 app.include_router(booking.router)
 app.include_router(chat.router)
 app.include_router(facilities.router)
+app.include_router(experiences.router)
 
 app.add_middleware(
     CORSMiddleware,
@@ -75,7 +77,9 @@ class CatchServerErrorMiddleware(BaseHTTPMiddleware):
                 posthog.capture_exception(exc)
             return JSONResponse(
                 status_code=500,
-                content={"detail": "Internal server error, please try again later"},
+                content={
+                    "detail": "Internal server error, please try again later"
+                },
                 headers={
                     "Access-Control-Allow-Origin": "*",
                     "Access-Control-Allow-Credentials": "true",

--- a/backend/api/app/models.py
+++ b/backend/api/app/models.py
@@ -60,7 +60,9 @@ class TaskRead(TaskBase):
 class BaseDetentionStatsReport(SQLModel):
     source_name: str = Field(index=True)  # e.g. FY25_detentionStats06202025
     fiscal_year: str = Field(index=True)  # e.g. "FY2025" (from name)
-    publication_date: datetime = Field(index=True)  # e.g. 2025-06-20 (from name)
+    publication_date: datetime = Field(
+        index=True
+    )  # e.g. 2025-06-20 (from name)
     publication_month: str = Field(index=True)  # Jan, Feb, Mar, etc.
     publication_year: int = Field(index=True)  # 2025
     raw_bytes: bytes = Field(default=None)
@@ -109,7 +111,9 @@ class AverageDailyPopulation(BaseAverageDailyPopulation, table=True):
     id: Optional[int] = Field(primary_key=True)
     uuid: Optional[UUID] = uuid()
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    report_id: int = Field(foreign_key="detention_stats_reports.id", index=True)
+    report_id: int = Field(
+        foreign_key="detention_stats_reports.id", index=True
+    )
     report: DetentionStatsReport = Relationship(
         back_populates="average_daily_populations"
     )
@@ -130,8 +134,12 @@ class AverageStayLength(BaseAverageStayLength, table=True):
     id: Optional[int] = Field(primary_key=True)
     uuid: Optional[UUID] = uuid()
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    report_id: int = Field(foreign_key="detention_stats_reports.id", index=True)
-    report: DetentionStatsReport = Relationship(back_populates="average_stay_lengths")
+    report_id: int = Field(
+        foreign_key="detention_stats_reports.id", index=True
+    )
+    report: DetentionStatsReport = Relationship(
+        back_populates="average_stay_lengths"
+    )
 
 
 class BaseBookOutRelease(SQLModel):
@@ -149,8 +157,12 @@ class BookOutRelease(BaseBookOutRelease, table=True):
     id: Optional[int] = Field(primary_key=True)
     uuid: Optional[UUID] = uuid()
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    report_id: int = Field(foreign_key="detention_stats_reports.id", index=True)
-    report: DetentionStatsReport = Relationship(back_populates="book_out_releases")
+    report_id: int = Field(
+        foreign_key="detention_stats_reports.id", index=True
+    )
+    report: DetentionStatsReport = Relationship(
+        back_populates="book_out_releases"
+    )
 
 
 class BaseBookIn(SQLModel):
@@ -167,7 +179,9 @@ class BookIn(BaseBookIn, table=True):
     id: Optional[int] = Field(primary_key=True)
     uuid: Optional[UUID] = uuid()
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    report_id: int = Field(foreign_key="detention_stats_reports.id", index=True)
+    report_id: int = Field(
+        foreign_key="detention_stats_reports.id", index=True
+    )
     report: DetentionStatsReport = Relationship(back_populates="book_ins")
 
 
@@ -182,7 +196,9 @@ class ProcessingDisposition(BaseProcessingDisposition, table=True):
     id: Optional[int] = Field(primary_key=True)
     uuid: Optional[UUID] = uuid()
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    report_id: int = Field(foreign_key="detention_stats_reports.id", index=True)
+    report_id: int = Field(
+        foreign_key="detention_stats_reports.id", index=True
+    )
     report: DetentionStatsReport = Relationship(
         back_populates="processing_dispositions"
     )
@@ -214,7 +230,9 @@ class BaseFacility(SQLModel):
     mandatory: Optional[float] = Field(default=None, index=True)
     guaranteed_minimum: Optional[float] = Field(default=None, index=True)
     last_inspection_type: Optional[str] = Field(default=None, index=True)
-    last_inspection_end_date: Optional[datetime] = Field(default=None, index=True)
+    last_inspection_end_date: Optional[datetime] = Field(
+        default=None, index=True
+    )
     # TODO need to re-name this column
     pending_fy25_inspection: Optional[str] = Field(default=None, index=True)
     last_inspection_standard: Optional[str] = Field(default=None, index=True)
@@ -226,7 +244,9 @@ class Facility(BaseFacility, table=True):
     id: Optional[int] = Field(primary_key=True)
     uuid: Optional[UUID] = uuid()
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    report_id: int = Field(foreign_key="detention_stats_reports.id", index=True)
+    report_id: int = Field(
+        foreign_key="detention_stats_reports.id", index=True
+    )
     report: DetentionStatsReport = Relationship(back_populates="facilities")
 
 
@@ -257,8 +277,12 @@ class FacilityRead(BaseFacility):
 # for chat
 class ChatMessageBase(SQLModel):
     type: str  # function_call, function_call_output, text, etc.
-    name: Optional[str] = Field(default=None)  # name of function for function_call
-    arguments: Optional[str] = Field(default=None)  # json text for function_call
+    name: Optional[str] = Field(
+        default=None
+    )  # name of function for function_call
+    arguments: Optional[str] = Field(
+        default=None
+    )  # json text for function_call
     call_id: Optional[str] = Field(
         default=None
     )  # id of function_call for function_call_output
@@ -328,3 +352,26 @@ class ChatRead(ChatBase):
     uuid: UUID
     created_at: datetime
     messages: list[ChatMessageRead]
+
+
+class BaseDetainmentExperience(SQLModel):
+    source_name: str = Field(index=True)
+    source_url: str
+    quote: str
+    reported_at: datetime = Field(index=True)
+
+
+class DetainmentExperience(BaseDetainmentExperience, table=True):
+    __tablename__ = "detainment_experiences"
+
+    id: Optional[int] = Field(primary_key=True)
+    uuid: Optional[UUID] = uuid()
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+
+class DetainmentExperienceRead(BaseDetainmentExperience):
+    id: int
+    uuid: UUID
+    created_at: datetime
+    updated_at: datetime

--- a/backend/api/app/routers/experiences.py
+++ b/backend/api/app/routers/experiences.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends, Request, Response
+from sqlmodel import select
+from app.db import get_session
+from app.limits import limiter
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.models import DetainmentExperience, DetainmentExperienceRead
+from app.utils.cache import cache_headers
+
+router = APIRouter(
+    prefix="/experiences",
+    tags=["experiences"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.get("/recent")
+@limiter.limit("10/second")
+async def recent(
+    request: Request,
+    response: Response,
+    session: AsyncSession = Depends(get_session),
+) -> list[DetainmentExperienceRead]:
+    cutoff = datetime.utcnow() - timedelta(days=180)
+    query = (
+        select(DetainmentExperience)
+        .where(DetainmentExperience.reported_at >= cutoff)
+        .order_by(DetainmentExperience.reported_at.desc())
+    )
+    results = await session.exec(query)
+    items = results.all()
+    response.headers.update(cache_headers(max_age=60 * 60))
+    return items

--- a/frontend/src/common/api/experiences.ts
+++ b/frontend/src/common/api/experiences.ts
@@ -1,0 +1,7 @@
+import { DetainmentExperience } from '../types';
+import axiosInstance from './axiosInstance';
+
+export async function getRecentExperiences() {
+  const response = await axiosInstance.get('/experiences/recent');
+  return response.data as DetainmentExperience[];
+}

--- a/frontend/src/common/hooks/experiences.ts
+++ b/frontend/src/common/hooks/experiences.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getRecentExperiences } from '../api/experiences';
+
+export default function useRecentExperiences() {
+  return useQuery({
+    queryKey: ['experiences', 'recent'],
+    queryFn: getRecentExperiences,
+    staleTime: 1000 * 60 * 60,
+  });
+}

--- a/frontend/src/common/types.ts
+++ b/frontend/src/common/types.ts
@@ -311,3 +311,14 @@ export type Facility = {
   last_inspection_standard?: string;
   last_final_rating?: string;
 };
+
+export type DetainmentExperience = {
+  id: number;
+  uuid: string;
+  source_name: string;
+  source_url: string;
+  quote: string;
+  reported_at: string;
+  created_at: string;
+  updated_at: string;
+};

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,8 +1,40 @@
 import { Box, Link } from '@cloudscape-design/components';
+import { useState } from 'react';
+import useRecentExperiences from '../common/hooks/experiences';
 
 export default function Footer() {
+  const [paused, setPaused] = useState(false);
+  const experiencesQuery = useRecentExperiences();
+
+  const experiences = experiencesQuery.data || [];
+
   return (
-    <footer role="contentinfo" className="flex justify-center items-end w-full p-4 mt-10">
+    <>
+      <div
+        className={`news-bar ${paused ? 'paused' : ''}`}
+        onMouseEnter={() => setPaused(true)}
+        onMouseLeave={() => setPaused(false)}
+        onFocus={() => setPaused(true)}
+        onBlur={() => setPaused(false)}
+        tabIndex={0}
+      >
+        <div className={`ticker ${paused ? 'paused' : ''}`}>
+          {experiences.map((exp) => (
+            <span key={exp.uuid} className="mx-4">
+              “{exp.quote}” -{' '}
+              <a
+                href={exp.source_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                {exp.source_name}
+              </a>
+            </span>
+          ))}
+        </div>
+      </div>
+      <footer role="contentinfo" className="flex justify-center items-end w-full p-4 mt-10 pb-16">
       <Box variant="p" textAlign="center" color="text-status-inactive" fontSize="body-s">
         <Box variant="p" textAlign="center" color="text-status-inactive" fontSize="body-s">
           Copyright © {new Date().getFullYear()} AI Escape LLC. All rights reserved.
@@ -80,5 +112,6 @@ export default function Footer() {
         </Box>
       </Box>
     </footer>
+    </>
   );
 }

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -8,6 +8,35 @@ body {
   overflow-x: hidden;
 }
 
+@keyframes ticker-scroll {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
+.news-bar {
+  background-color: #1a202c;
+  color: #ffffff;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  overflow: hidden;
+  z-index: 1000;
+}
+
+.ticker {
+  display: inline-block;
+  white-space: nowrap;
+  animation: ticker-scroll 25s linear infinite;
+}
+
+.ticker.paused {
+  animation-play-state: paused;
+}
+
 div:has(nav[aria-label="Side navigation"]) {
   z-index: 800 !important;
 }


### PR DESCRIPTION
## Summary
- backend: add `DetainmentExperience` model and router
- expose `/experiences/recent` endpoint
- include new router in FastAPI app
- frontend: add API helpers and React hook for recent experiences
- create scrolling ticker in sticky footer
- global CSS for ticker animation

## Testing
- `yarn lint`
- `yarn tsc --noEmit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881796bea248333b95ae5544cfec827