### PR TITLE
ci: publish releases after production deploys

### DIFF
--- a/.github/scripts/upsert-prod-release.sh
+++ b/.github/scripts/upsert-prod-release.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+: "${GITHUB_SERVER_URL:?GITHUB_SERVER_URL is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+: "${SERVICE_NAME:?SERVICE_NAME is required}"
+: "${SERVICE_URL:?SERVICE_URL is required}"
+: "${DEPLOY_NOTES:?DEPLOY_NOTES is required}"
+
+short_sha="${GITHUB_SHA:0:7}"
+tag="prod-${GITHUB_SHA}"
+release_name="Production deploy ${short_sha}"
+run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+commit_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+service_key="$(printf '%s' "${SERVICE_NAME}" |
+  tr '[:upper:]' '[:lower:]' |
+  tr -c '[:alnum:]' '-')"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+body_file="${workdir}/body.md"
+block_file="${workdir}/${service_key}.md"
+
+if gh release view "${tag}" --json body --jq .body >"${body_file}" 2>/dev/null; then
+  release_exists="true"
+else
+  release_exists="false"
+  cat >"${body_file}" <<EOF
+# ${release_name}
+
+Canonical production release for commit [\`${short_sha}\`](${commit_url}).
+
+This release is created only after a production deploy workflow succeeds.
+Rerunning a deploy updates this release instead of creating a duplicate.
+EOF
+fi
+
+cat >"${block_file}" <<EOF
+<!-- prod-release:service:${service_key}:start -->
+## ${SERVICE_NAME}
+
+- Production SHA: [\`${GITHUB_SHA}\`](${commit_url})
+- Service URL: ${SERVICE_URL}
+- Deploy run: ${run_url}
+- Deploy notes: ${DEPLOY_NOTES}
+<!-- prod-release:service:${service_key}:end -->
+EOF
+
+START_MARKER="<!-- prod-release:service:${service_key}:start -->" \
+END_MARKER="<!-- prod-release:service:${service_key}:end -->" \
+BLOCK_FILE="${block_file}" \
+BODY_FILE="${body_file}" \
+perl -0pi -e '
+  use strict;
+  use warnings;
+
+  my $start = $ENV{"START_MARKER"};
+  my $end = $ENV{"END_MARKER"};
+  my $block_file = $ENV{"BLOCK_FILE"};
+  open(my $fh, "<", $block_file) or die "cannot open block: $!";
+  local $/;
+  my $block = <$fh>;
+  close($fh);
+
+  if (index($_, $start) >= 0 && index($_, $end) >= 0) {
+    s/\Q$start\E.*?\Q$end\E/$block/s;
+  } else {
+    s/\s*\z/\n\n$block/s;
+  }
+' "${body_file}"
+
+if [[ "${release_exists}" == "true" ]]; then
+  gh release edit "${tag}" \
+    --title "${release_name}" \
+    --notes-file "${body_file}"
+else
+  gh release create "${tag}" \
+    --target "${GITHUB_SHA}" \
+    --title "${release_name}" \
+    --notes-file "${body_file}"
+fi

--- a/.github/workflows/deploy-backend.yaml
+++ b/.github/workflows/deploy-backend.yaml
@@ -29,3 +29,14 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: flyctl deploy --remote-only
+
+  publish-release:
+    needs: deploy
+    if: ${{ success() }}
+    uses: ./.github/workflows/publish-prod-release.yaml
+    permissions:
+      contents: write
+    with:
+      service_name: Backend API
+      service_url: https://open-ice-api.fly.dev
+      deploy_notes: Fly.io production API deploy from backend/api using flyctl deploy --remote-only.

--- a/.github/workflows/deploy-frontend.yaml
+++ b/.github/workflows/deploy-frontend.yaml
@@ -3,8 +3,8 @@ on:
   push:
     branches: [main]
     paths:
-      - 'frontend/**'
-      - '.github/workflows/deploy-frontend.yaml'
+      - "frontend/**"
+      - ".github/workflows/deploy-frontend.yaml"
 
 permissions:
   contents: read
@@ -13,6 +13,8 @@ permissions:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    outputs:
+      service_url: ${{ steps.deploy-pages.outputs.url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -20,8 +22,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '25'
-          cache: 'npm'
+          node-version: "25"
+          cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
@@ -33,9 +35,21 @@ jobs:
         run: npm run build
 
       - name: Deploy to Cloudflare Pages
+        id: deploy-pages
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
           directory: frontend/build
+
+  publish-release:
+    needs: build-and-deploy
+    if: ${{ success() }}
+    uses: ./.github/workflows/publish-prod-release.yaml
+    permissions:
+      contents: write
+    with:
+      service_name: Frontend Web
+      service_url: ${{ needs.build-and-deploy.outputs.service_url }}
+      deploy_notes: Cloudflare Pages production web deploy from frontend/build.

--- a/.github/workflows/publish-prod-release.yaml
+++ b/.github/workflows/publish-prod-release.yaml
@@ -1,0 +1,38 @@
+name: Publish Production Release
+
+on:
+  workflow_call:
+    inputs:
+      service_name:
+        description: Production service that was deployed.
+        required: true
+        type: string
+      service_url:
+        description: Public production URL for the deployed service.
+        required: true
+        type: string
+      deploy_notes:
+        description: Notes describing the production deploy.
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: prod-release-${{ github.sha }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Upsert production release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SERVICE_NAME: ${{ inputs.service_name }}
+          SERVICE_URL: ${{ inputs.service_url }}
+          DEPLOY_NOTES: ${{ inputs.deploy_notes }}
+        run: .github/scripts/upsert-prod-release.sh

--- a/README.md
+++ b/README.md
@@ -31,7 +31,18 @@ Each subdirectory provides its own `README.md` with detailed setup instructions.
 
 Contributions are welcome! Feel free to open issues or submit pull requests. By participating in this project you agree to abide by the code of conduct defined in the individual directories.
 
+## Production Releases
+
+Production deploy workflows publish canonical GitHub Releases only after a
+production deploy succeeds. The release tag is `prod-<full commit SHA>`, so
+rerunning the same deploy updates the existing release instead of creating a
+duplicate.
+
+Each release records the deployed production SHA, the service URL, the GitHub
+Actions run URL, and deploy notes for each service that deployed from that
+commit. Historical releases are not backfilled unless the production
+SHA-to-deploy mapping is unambiguous under this policy.
+
 ## License
 
 This project is licensed under the [Apache License 2.0](LICENSE). All code is open‑source. No public funds were used in its development.
-


### PR DESCRIPTION
## Summary
- add a reusable production release workflow and idempotent release upsert script
- wire backend and frontend production deploy workflows to publish/update `prod-<full SHA>` GitHub Releases after successful deploys
- document the canonical production release policy and no-historical-backfill rule

Kanban task: t_c3b8f57c

## Test plan
- `bash -n .github/scripts/upsert-prod-release.sh`
- `npx --yes prettier@3.5.3 --check .github/workflows/*.yaml`
- `npx --yes github-actionlint .github/workflows/*.yaml`
- `git diff --check`
- local stub harness for create/update release paths: `create path ok`, `update path ok`